### PR TITLE
Update golang version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.16-alpine AS build
+FROM golang:1.17-alpine AS build
 ARG VERSION=latest
 ARG GIT_HASH
 


### PR DESCRIPTION
The version go.mod and Dockerfile are incompatible. Before this PR while building the image, the following error is emitted.

```
@sbs2001 ➜ /workspaces/spdx-sbom-generator (main) $ docker build . -t spdx 
[+] Building 40.9s (14/19)                                                                                                  
 => => sha256:0435e09637941e35cccdf9cf9171571811d2fdfe72c27e39543a718d38d28668 156B / 156B                             1.2s
 => => extracting sha256:666ba61612fd7c93393f9a5bc1751d8a9929e32d51501dba691da9e8232bc87b                              0.1s
 => => extracting sha256:8ed8ca4862056a130f714accb3538decfa0663fec84e635d8b5a0a3305353dee                              0.0s
 => => extracting sha256:ca4bf87e467a8cacf62c9b01c7d6d43f6ca4bb9b0fc9146fbb906b05aee56cc1                              4.0s
 => => extracting sha256:0435e09637941e35cccdf9cf9171571811d2fdfe72c27e39543a718d38d28668                              0.0s
 => [stage-1 1/6] FROM docker.io/library/alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2  3.4s
 => => resolve docker.io/library/alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad        0.1s
 => => sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad 1.64kB / 1.64kB                         0.0s
 => => sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870 528B / 528B                             0.0s
 => => sha256:9c6f0724472873bb50a2ae67a9e7adcb57673a183cea8b06eb778dca859181b5 1.47kB / 1.47kB                         [+] Building 41.0s (14/19)                                                                                                  > sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49 2.81MB / 2.81MB                          => => sha256:0435e09637941e35cccdf9cf9171571811d2fdfe72c27e39543a718d38d28668 156B / 156B                             1.2s=> extracting sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49                               => => extracting sha256:666ba61612fd7c93393f9a5bc1751d8a9929e32d51501dba691da9e8232bc87b                              0.1s[stage-1 2/6] RUN apk add --update ruby && gem install bundler                                                      => => extracting sha256:8ed8ca4862056a130f714accb3538decfa0663fec84e635d8b5a0a3305353dee                              0.0s[stage-1 3/6] RUN apk add go                                                                                        => => extracting sha256:ca4bf87e467a8cacf62c9b01c7d6d43f6ca4bb9b0fc9146fbb906b05aee56cc1                              4.0s[build 2/8] WORKDIR /src                                                                                            => => extracting sha256:0435e09637941e35cccdf9cf9171571811d2fdfe72c27e39543a718d38d28668                              0.0s[build 3/8] COPY go.mod go.sum ./                                                                                   => [stage-1 1/6] FROM docker.io/library/alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2  3.4s[build 4/8] RUN go mod download                                                                                   2 => => resolve docker.io/library/alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad        0.1s[stage-1 4/6] RUN apk add --update maven                                                                            => => sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad 1.64kB / 1.64kB                         0.0s[stage-1 5/6] RUN apk add --update nodejs npm && npm install -g yarn                                                => => sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870 528B / 528B                             0.0s[build 5/8] COPY / .                                                                                                => => sha256:9c6f0724472873bb50a2ae67a9e7adcb57673a183cea8b06eb778dca859181b5 1.47kB / 1.47kB                         [+] Building 41.2s (15/19)                                                                                                  > sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49 2.81MB / 2.81MB                          => => extracting sha256:666ba61612fd7c93393f9a5bc1751d8a9929e32d51501dba691da9e8232bc87b                              0.1s=> extracting sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49                               => => extracting sha256:8ed8ca4862056a130f714accb3538decfa0663fec84e635d8b5a0a3305353dee                              0.0s[stage-1 2/6] RUN apk add --update ruby && gem install bundler                                                      => => extracting sha256:ca4bf87e467a8cacf62c9b01c7d6d43f6ca4bb9b0fc9146fbb906b05aee56cc1                              4.0s[stage-1 3/6] RUN apk add go                                                                                        => => extracting sha256:0435e09637941e35cccdf9cf9171571811d2fdfe72c27e39543a718d38d28668                              0.0s[build 2/8] WORKDIR /src                                                                                            => [stage-1 1/6] FROM docker.io/library/alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2  3.4s[build 3/8] COPY go.mod go.sum ./                                                                                   => => resolve docker.io/library/alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad        0.1s[build 4/8] RUN go mod download                                                                                   2 => => sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad 1.64kB / 1.64kB                         0.0s[stage-1 4/6] RUN apk add --update maven                                                                            => => sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870 528B / 528B                             0.0s[stage-1 5/6] RUN apk add --update nodejs npm && npm install -g yarn                                                => => sha256:9c6f0724472873bb50a2ae67a9e7adcb57673a183cea8b06eb778dca859181b5 1.47kB / 1.47kB                         0.0s[build 5/8] COPY / .                                                                                                => => sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49 2.81MB / 2.81MB                         [+] Building 43.2s (17/19)                                                                                             
 => [internal] load build definition from Dockerfile                                                              0.5s  => => transferring dockerfile: 35B                                                                               0.0s
 => [internal] load .dockerignore                                                                                 0.5s  => => transferring context: 2B                                                                                   0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                  1.3s  => [internal] load metadata for docker.io/library/golang:1.16-alpine                                             0.4s
 => [internal] load build context                                                                                 0.2s  => => transferring context: 11.60kB                                                                              0.0s
 => [build 1/8] FROM docker.io/library/golang:1.16-alpine@sha256:5616dca835fa90ef13a843824ba58394dad356b7d56198f  9.7s  => => resolve docker.io/library/golang:1.16-alpine@sha256:5616dca835fa90ef13a843824ba58394dad356b7d56198fb7c93c  0.1s
 => => sha256:5616dca835fa90ef13a843824ba58394dad356b7d56198fb7c93cbe76d7d67fe 1.65kB / 1.65kB                    0.0s2 => => sha256:9743f230f26d1e300545f0330fd4a514f554c535d967563ee77bf634906502b6 1.36kB / 1.36kB                    0.0s
 => => sha256:7642119cd16177d874dcbfe1c550affd336dbe4cabb3339ef685ac1d6ec71ccc 5.17kB / 5.17kB                    0.0s  => => sha256:59bf1c3509f33515622619af21ed55bbe26d24913cedbca106468a5fb37a50c3 2.82MB / 2.82MB                    0.4s
 => => sha256:8ed8ca4862056a130f714accb3538decfa0663fec84e635d8b5a0a3305353dee 155B / 155B                        0.9s  => => sha256:666ba61612fd7c93393f9a5bc1751d8a9929e32d51501dba691da9e8232bc87b 282.16kB / 282.16kB                0.6s
 => => extracting sha256:59bf1c3509f33515622619af21ed55bbe26d24913cedbca106468a5fb37a50c3                         0.9s  => => sha256:ca4bf87e467a8cacf62c9b01c7d6d43f6ca4bb9b0fc9146fbb906b05aee56cc1 105.89MB / 105.89MB                2.8s
 => => sha256:0435e09637941e35cccdf9cf9171571811d2fdfe72c27e39543a718d38d28668 156B / 156B                        1.2s  => => extracting sha256:666ba61612fd7c93393f9a5bc1751d8a9929e32d51501dba691da9e8232bc87b                         0.1s
 => => extracting sha256:8ed8ca4862056a130f714accb3538decfa0663fec84e635d8b5a0a3305353dee                         0.0s
 => => extracting sha256:ca4bf87e467a8cacf62c9b01c7d6d43f6ca4bb9b0fc9146fbb906b05aee56cc1                         4.0s
 => => extracting sha256:0435e09637941e35cccdf9cf9171571811d2fdfe72c27e39543a718d38d28668                         0.0s
 => [stage-1 1/6] FROM docker.io/library/alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d97  3.4s
 => => resolve docker.io/library/alpine@sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad   0.1s
 => => sha256:bc41182d7ef5ffc53a40b044e725193bc10142a1243f395ee852a8d9730fc2ad 1.64kB / 1.64kB                    0.0s
 => => sha256:1304f174557314a7ed9eddb4eab12fed12cb0cd9809e4c28f29af86979a3c870 528B / 528B                        0.0s
 => => sha256:9c6f0724472873bb50a2ae67a9e7adcb57673a183cea8b06eb778dca859181b5 1.47kB / 1.47kB                    0.0s
 => => sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49 2.81MB / 2.81MB                    1.5s
 => => extracting sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49                         0.2s
 => [stage-1 2/6] RUN apk add --update ruby && gem install bundler                                                4.3s
 => [stage-1 3/6] RUN apk add go                                                                                  6.6s
 => [build 2/8] WORKDIR /src                                                                                      1.0s
 => [build 3/8] COPY go.mod go.sum ./                                                                             1.3s
 => [build 4/8] RUN go mod download                                                                              26.5s
 => [stage-1 4/6] RUN apk add --update maven                                                                      6.6s
 => [stage-1 5/6] RUN apk add --update nodejs npm && npm install -g yarn                                          3.3s
 => [build 5/8] COPY / .                                                                                          0.4s
 => [build 6/8] RUN GO111MODULE=on GOFLAGS=-mod=vendor go mod vendor                                              1.3s
 => ERROR [build 7/8] RUN GO111MODULE=on GOFLAGS=-mod=vendor go mod tidy                                          0.8s
------
 > [build 7/8] RUN GO111MODULE=on GOFLAGS=-mod=vendor go mod tidy:
#17 0.666 go mod tidy: go.mod file indicates go 1.17, but maximum supported version is 1.16
------
executor failed running [/bin/sh -c GO111MODULE=on GOFLAGS=-mod=vendor go mod tidy]: exit code: 1
```